### PR TITLE
Run full unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,30 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Python dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt pytest-cov
       - name: Python unit tests
-        run: PYTHONPATH=src python test/unit/slurmdb_validation.test.py
+        run: |
+          PYTHONPATH=src pytest test/unit/*.py --cov=src --cov-report=xml:test-coverage-python.xml
+      - name: Upload Python coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-coverage
+          path: test-coverage-python.xml
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+      - name: Install Node dependencies
+        run: npm install c8 --no-save
       - name: Node unit tests
-        run: node test/unit/calculator.test.js
+        run: |
+          for file in test/unit/*.test.js; do npx c8 --clean=false node "$file"; done
+          npx c8 report --reporter=lcov --reporter=text
+      - name: Upload Node coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-coverage
+          path: coverage
 
   integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- run pytest on all Python unit tests and upload coverage
- run every JS unit test with c8 coverage and upload results

## Testing
- `PYTHONPATH=src pytest test/unit/*.py --cov=src --cov-report=xml:test-coverage-python.xml` (fails: ModuleNotFoundError: No module named 'auth_boundaries')
- `for file in test/unit/*.test.js; do npx c8 --clean=false node "$file"; done`
- `npx c8 report --reporter=lcov --reporter=text`


------
https://chatgpt.com/codex/tasks/task_e_6892d330656883249dab0a13bf9c284a