### PR TITLE
Add GPU-hour billing support

### DIFF
--- a/src/rates-schema.json
+++ b/src/rates-schema.json
@@ -1,14 +1,28 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "RatesConfig",
-  "description": "Schema for core hour rate configuration",
+  "description": "Schema for core and GPU hour rate configuration",
   "type": "object",
   "properties": {
     "defaultRate": {
       "type": "number",
       "minimum": 0
     },
+    "defaultGpuRate": {
+      "type": "number",
+      "minimum": 0
+    },
     "historicalRates": {
+      "type": "object",
+      "patternProperties": {
+        "^[0-9]{4}-(0[1-9]|1[0-2])$": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "historicalGpuRates": {
       "type": "object",
       "patternProperties": {
         "^[0-9]{4}-(0[1-9]|1[0-2])$": {
@@ -25,6 +39,10 @@
           "type": "object",
           "properties": {
             "rate": {
+              "type": "number",
+              "minimum": 0
+            },
+            "gpuRate": {
               "type": "number",
               "minimum": 0
             },

--- a/src/rates.json
+++ b/src/rates.json
@@ -1,17 +1,23 @@
 {
   "defaultRate": 0.02,
+  "defaultGpuRate": 0.2,
   "historicalRates": {
     "2024-01": 0.015
   },
+  "historicalGpuRates": {
+    "2024-01": 0.15
+  },
   "overrides": {
     "research": {
-      "rate": 0.01
+      "rate": 0.01,
+      "gpuRate": 0.1
     },
     "education": {
       "discount": 0.5
     },
     "special": {
       "rate": 0.025,
+      "gpuRate": 0.25,
       "discount": 0.1
     }
   }

--- a/test/unit/billing_summary.test.py
+++ b/test/unit/billing_summary.test.py
@@ -33,11 +33,11 @@ class BillingSummaryTests(unittest.TestCase):
             with mock.patch.object(SlurmDB, 'fetch_invoices', return_value=invoices):
                 db = SlurmDB()
                 summary = db.export_summary('2023-10-01', '2023-10-31')
-        self.assertEqual(summary['summary']['total'], 0.2)
+        self.assertEqual(summary['summary']['total'], 1.2)
         self.assertEqual(summary['details'][0]['account'], 'acct')
         self.assertEqual(summary['details'][0]['core_hours'], 10.0)
         self.assertEqual(summary['details'][0]['gpu_hours'], 5.0)
-        self.assertEqual(summary['details'][0]['cost'], 0.2)
+        self.assertEqual(summary['details'][0]['cost'], 1.2)
         self.assertEqual(summary['summary']['gpu_hours'], 5.0)
         self.assertEqual(summary['invoices'][0]['file'], 'inv1.pdf')
 

--- a/test/unit/calculator.test.js
+++ b/test/unit/calculator.test.js
@@ -5,31 +5,38 @@ const { calculateCharges, loadRatesConfig } = require('../../src/cost-calculator
 
 function testFileConfig() {
   const usage = [
-    { account: 'education', date: '2024-01-15', core_hours: 100 },
-    { account: 'research', date: '2024-02-01', core_hours: 50 },
-    { account: 'special', date: '2024-02-01', core_hours: 100 },
+    { account: 'education', date: '2024-01-15', core_hours: 100, gpu_hours: 10 },
+    { account: 'research', date: '2024-02-01', core_hours: 50, gpu_hours: 5 },
+    { account: 'special', date: '2024-02-01', core_hours: 100, gpu_hours: 20 },
     { account: 'other', date: '2024-02-01', core_hours: 10 }
   ];
   const config = loadRatesConfig();
   const charges = calculateCharges(usage, config);
-  assert.strictEqual(charges['2024-01'].education.cost, 100 * 0.015 * 0.5);
-  assert.strictEqual(charges['2024-02'].research.cost, 50 * 0.01);
-  assert.strictEqual(charges['2024-02'].special.cost, 100 * 0.025 * 0.9);
+  assert.strictEqual(charges['2024-01'].education.cost, (100 * 0.015 + 10 * 0.15) * 0.5);
+  assert.strictEqual(charges['2024-02'].research.cost, 50 * 0.01 + 5 * 0.1);
+  assert.strictEqual(charges['2024-02'].special.cost, (100 * 0.025 + 20 * 0.25) * 0.9);
   assert.strictEqual(charges['2024-02'].other.cost, 10 * 0.02);
+  assert.strictEqual(charges['2024-01'].education.gpu_hours, 10);
 }
 
 function testPassedConfig() {
   const usage = [
-    { account: 'acct', date: '2024-03-01', core_hours: 100 }
+    { account: 'acct', date: '2024-03-01', core_hours: 100, gpu_hours: 10 }
   ];
-  const config = { defaultRate: 0.02, historicalRates: { '2024-03': 0.03 }, overrides: { acct: { discount: 0.25 } } };
+  const config = {
+    defaultRate: 0.02,
+    defaultGpuRate: 0.2,
+    historicalRates: { '2024-03': 0.03 },
+    historicalGpuRates: { '2024-03': 0.3 },
+    overrides: { acct: { discount: 0.25 } }
+  };
   const charges = calculateCharges(usage, config);
-  assert.strictEqual(charges['2024-03'].acct.cost, 100 * 0.03 * 0.75);
+  assert.strictEqual(charges['2024-03'].acct.cost, (100 * 0.03 + 10 * 0.3) * 0.75);
 }
 
 function testInvalidUsageIgnored() {
   const usage = [
-    { account: 'bad', date: '2024-04-01', core_hours: 'NaN' }
+    { account: 'bad', date: '2024-04-01', core_hours: 'NaN', gpu_hours: 'NaN' }
   ];
   const charges = calculateCharges(usage, { defaultRate: 0.01 });
   assert.deepStrictEqual(charges, {});
@@ -77,10 +84,10 @@ function testNegativeInputs() {
   const charges = calculateCharges(usage, config);
   const may = charges['2024-05'];
   assert.ok(!('negHours' in may));
-  assert.deepStrictEqual(may.negRate, { core_hours: 5, cost: 0 });
-  assert.deepStrictEqual(may.discLow, { core_hours: 5, cost: 0.5 });
-  assert.deepStrictEqual(may.discHigh, { core_hours: 5, cost: 0 });
-  assert.deepStrictEqual(may.def, { core_hours: 5, cost: 0 });
+  assert.deepStrictEqual(may.negRate, { core_hours: 5, gpu_hours: 0, cost: 0 });
+  assert.deepStrictEqual(may.discLow, { core_hours: 5, gpu_hours: 0, cost: 0.5 });
+  assert.deepStrictEqual(may.discHigh, { core_hours: 5, gpu_hours: 0, cost: 0 });
+  assert.deepStrictEqual(may.def, { core_hours: 5, gpu_hours: 0, cost: 0 });
 }
 
 function testRoundingTotals() {
@@ -91,6 +98,7 @@ function testRoundingTotals() {
   const charges = calculateCharges(usage, { defaultRate: 0.333 });
   const june = charges['2024-06'];
   assert.strictEqual(june.round.core_hours, 0.67);
+  assert.strictEqual(june.round.gpu_hours, 0);
   assert.strictEqual(june.round.cost, 0.22);
 }
 


### PR DESCRIPTION
## Summary
- add GPU-hour rates to cost calculator and SlurmDB export summary
- extend rate configuration schema and defaults for GPU billing
- update unit tests and billing summary for GPU-hour charges

## Testing
- `PYTHONPATH=src ./test/check-application`


------
https://chatgpt.com/codex/tasks/task_e_6894bf2e69cc8324ba9585abf847d13f