### PR TITLE
Display detailed billing data load errors

### DIFF
--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -51,7 +51,7 @@ function useBillingData() {
       setError(null);
     } catch (e) {
       console.error(e);
-      setError(e);
+      setError(e.message || String(e));
     }
   }, []);
 
@@ -1074,7 +1074,13 @@ function App() {
       )
     ),
     view !== 'settings' && !data && !error && React.createElement('p', null, 'Loading...'),
-    view !== 'settings' && error && React.createElement('p', { className: 'error' }, 'Failed to load data'),
+    view !== 'settings' &&
+      error &&
+      React.createElement(
+        'p',
+        { className: 'error' },
+        `Failed to load data: ${error}`
+      ),
     data &&
       view === 'summary' &&
       React.createElement(Summary, {


### PR DESCRIPTION
## Summary
- provide detailed reason when billing data fails to load
- capture error messages in useBillingData hook

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6894c5fdc71883248aae06f08588e927