### PR TITLE
List all cluster accounts in settings

### DIFF
--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -892,14 +892,10 @@ function Rates({ onRatesUpdated }) {
       try {
         let json;
         if (window.cockpit && window.cockpit.spawn) {
-          const { start, end } = getBillingPeriod();
           const args = [
             'python3',
             `${PLUGIN_BASE}/slurmdb.py`,
-            '--start',
-            start,
-            '--end',
-            end,
+            '--accounts',
             '--output',
             '-',
           ];

--- a/test/check-application
+++ b/test/check-application
@@ -10,3 +10,4 @@ PYTHONPATH=src python test/unit/slurm_schema_dump.test.py
 PYTHONPATH=src python test/unit/billing_summary.test.py
 PYTHONPATH=src python test/unit/invoice_retrieval.test.py
 PYTHONPATH=src python test/unit/auth_boundaries.test.py
+PYTHONPATH=src python test/unit/accounts_listing.test.py

--- a/test/unit/accounts_listing.test.py
+++ b/test/unit/accounts_listing.test.py
@@ -1,0 +1,81 @@
+import unittest
+from slurmdb import SlurmDB
+
+
+class AccountListingTests(unittest.TestCase):
+    def test_fetch_accounts_from_acct_table(self):
+        db = SlurmDB()
+        db.connect = lambda: None
+
+        class FakeCursor:
+            def __init__(self):
+                self.last_query = ""
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+            def execute(self, query, params=None):
+                self.last_query = query
+
+            def fetchone(self):
+                if "SHOW TABLES LIKE" in self.last_query:
+                    return {"name": "acct_table"}
+                return None
+
+            def fetchall(self):
+                if "SELECT name FROM acct_table" in self.last_query:
+                    return [{"name": "acct1"}, {"name": "acct2"}]
+                return []
+
+        class FakeConn:
+            def cursor(self):
+                return FakeCursor()
+
+        db._conn = FakeConn()
+        accounts = db.fetch_all_accounts()
+        self.assertEqual(accounts, ["acct1", "acct2"])
+
+    def test_fetch_accounts_from_assoc_table_when_acct_table_missing(self):
+        db = SlurmDB(cluster="localcluster")
+        db.connect = lambda: None
+
+        class FakeCursor:
+            def __init__(self):
+                self.last_query = ""
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+            def execute(self, query, params=None):
+                self.last_query = query
+
+            def fetchone(self):
+                # acct_table does not exist
+                return None
+
+            def fetchall(self):
+                if "localcluster_assoc_table" in self.last_query:
+                    return [
+                        {"acct": "acct1"},
+                        {"acct": "acct2"},
+                        {"acct": "acct1"},
+                    ]
+                return []
+
+        class FakeConn:
+            def cursor(self):
+                return FakeCursor()
+
+        db._conn = FakeConn()
+        accounts = db.fetch_all_accounts()
+        self.assertEqual(accounts, ["acct1", "acct2"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fetch full account list from SlurmDB independent of billing period
- expose `--accounts` option in `slurmdb.py` and use it in settings UI
- add unit tests for account listing and include them in test suite

## Testing
- `./test/check-application`


------
https://chatgpt.com/codex/tasks/task_e_689505bc1548832486b1c30128e61a61