### PR TITLE
Add cluster core count setting for cost recovery ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository now includes a responsive Cockpit UI built with React.  The inte
 - **Detailed cost drill-downs** (core‑hours, GPU-hours) for per‑account transparency.
 - **Historical billing data** accessible from account inception for auditing and trend analysis.
 - **Organization-wide views** consolidating charges across all member Slurm accounts.
-- **Configurable rate table** with per-account overrides, editable from a dedicated Settings tab.
+- **Configurable rate table** with per-account overrides and cluster core count, editable from a dedicated Settings tab.
 
 
 ## 📁 Project Structure

--- a/src/rates.json
+++ b/src/rates.json
@@ -1,6 +1,7 @@
 {
   "defaultRate": 0.02,
   "defaultGpuRate": 0.2,
+  "clusterCores": 100,
   "historicalRates": {
     "2024-01": 0.015
   },

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -866,7 +866,10 @@ function Rates({ onRatesUpdated }) {
         }
         if (cancelled) return;
         const json = JSON.parse(text);
-        setConfig({ defaultRate: json.defaultRate });
+        setConfig({
+          defaultRate: json.defaultRate,
+          clusterCores: json.clusterCores || ''
+        });
         const ovrs = json.overrides
           ? Object.entries(json.overrides).map(([account, cfg]) => ({
               account,
@@ -946,6 +949,16 @@ function Rates({ onRatesUpdated }) {
 
       const json = { defaultRate };
 
+      if (config.clusterCores !== undefined && config.clusterCores !== '') {
+        const cores = parseInt(config.clusterCores, 10);
+        if (!Number.isFinite(cores) || cores < 0) {
+          console.warn('Invalid cluster core count:', config.clusterCores);
+          setError('Invalid cluster core count');
+          return;
+        }
+        json.clusterCores = cores;
+      }
+
       if (overrides.length) {
         const overridesJson = {};
         overrides.forEach(o => {
@@ -1017,6 +1030,22 @@ function Rates({ onRatesUpdated }) {
           value: config.defaultRate,
           onChange: e =>
             setConfig({ ...config, defaultRate: e.target.value })
+        })
+      )
+    ),
+    React.createElement(
+      'div',
+      null,
+      React.createElement(
+        'label',
+        null,
+        'Total Cluster Cores: ',
+        React.createElement('input', {
+          type: 'number',
+          step: '1',
+          value: config.clusterCores,
+          onChange: e =>
+            setConfig({ ...config, clusterCores: e.target.value })
         })
       )
     ),

--- a/test/unit/billing_summary.test.py
+++ b/test/unit/billing_summary.test.py
@@ -186,6 +186,30 @@ class BillingSummaryTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 db.export_summary('2023-10-01', '2023-10-31')
 
+    def test_export_summary_projected_revenue(self):
+        usage = {
+            '2024-02': {
+                'acct': {'core_hours': 10.0, 'users': {}}
+            }
+        }
+
+        def fake_open(path, *args, **kwargs):
+            if path.endswith('rates.json'):
+                return io.StringIO('{"defaultRate": 0.02, "clusterCores": 100}')
+            return open_orig(path, *args, **kwargs)
+
+        open_orig = open
+        with mock.patch.object(
+            SlurmDB,
+            'aggregate_usage',
+            return_value=(usage, {'daily': {}, 'monthly': {}, 'yearly': {}}),
+        ), mock.patch.object(SlurmDB, 'fetch_invoices', return_value=[]), mock.patch(
+            'builtins.open', side_effect=fake_open
+        ):
+            db = SlurmDB()
+            summary = db.export_summary('2024-02-01', '2024-02-29')
+        self.assertAlmostEqual(summary['summary']['projected_revenue'], 1392.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow entering total cluster core count in settings
- compute projected revenue using cluster core count for cost recovery ratio
- test projected revenue calculation

## Testing
- `./test/check-application`

------
https://chatgpt.com/codex/tasks/task_e_68950a484a088324b845e9588c84b501