### PR TITLE
Improve profile loading error handling

### DIFF
--- a/src/invoice.py
+++ b/src/invoice.py
@@ -11,6 +11,7 @@ import io
 import json
 import os
 import sys
+import logging
 from datetime import datetime
 
 # Reportlab is required for PDF generation. If it's missing, emit a clear
@@ -38,8 +39,13 @@ def _load_profile(base_dir):
     try:
         with open(path, "r", encoding="utf-8") as fh:
             return json.load(fh)
-    except Exception:
+    except FileNotFoundError:
         return {}
+    except json.JSONDecodeError as exc:
+        logging.error("Failed to parse %s: %s", path, exc)
+    except OSError as exc:
+        logging.error("Unable to read %s: %s", path, exc)
+    return {}
 
 
 def _profile_sections(profile):

--- a/test/check-application
+++ b/test/check-application
@@ -11,3 +11,4 @@ PYTHONPATH=src python test/unit/billing_summary.test.py
 PYTHONPATH=src python test/unit/invoice_retrieval.test.py
 PYTHONPATH=src python test/unit/auth_boundaries.test.py
 PYTHONPATH=src python test/unit/accounts_listing.test.py
+PYTHONPATH=src python test/unit/profile_loading.test.py

--- a/test/unit/profile_loading.test.py
+++ b/test/unit/profile_loading.test.py
@@ -1,0 +1,33 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+import logging
+
+from invoice import _load_profile
+
+
+class LoadProfileTests(unittest.TestCase):
+    def test_missing_file_returns_empty_profile(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(_load_profile(td), {})
+
+    def test_invalid_json_logs_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "institution.json")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("{invalid")
+            with self.assertLogs(level="ERROR") as cm:
+                self.assertEqual(_load_profile(td), {})
+            self.assertIn("Failed to parse", cm.output[0])
+
+    def test_os_error_logs_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            with mock.patch("builtins.open", side_effect=PermissionError("denied")):
+                with self.assertLogs(level="ERROR") as cm:
+                    self.assertEqual(_load_profile(td), {})
+        self.assertIn("Unable to read", cm.output[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- log JSON parsing and read errors when loading institution profiles
- add unit tests for profile loading failures and include them in test script

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68bf9c694388832485a78c2b0b886faa