### PR TITLE
fix: surface invoice generation errors

### DIFF
--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -923,7 +923,10 @@ function Details({
       }
       const output = await window.cockpit.spawn(
         ['python3', `${PLUGIN_BASE}/invoice.py`],
-        { input: JSON.stringify(invoiceData), err: 'out' }
+        // Capture stderr as the error message so problems like missing
+        // Python dependencies surface to the user instead of a generic
+        // "python3 exited with code 1" message.
+        { input: JSON.stringify(invoiceData), err: 'message' }
       );
       const trimmed = output.trim();
       if (!trimmed) {


### PR DESCRIPTION
## Summary
- capture Python stderr when exporting invoices to provide actionable error messages

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68c0ba54bb2483249d1260a8e21153cf